### PR TITLE
Retrieve the centroid of a country from the country data file #1686

### DIFF
--- a/js/dataprovider.js
+++ b/js/dataprovider.js
@@ -362,10 +362,11 @@ DataProvider.prototype.fetchCountryNames = function() {
             let bbox = bboxParts[j].split(',');
             bboxes.push(bbox);
         }
-        let c = new Country(code, name, continent, population, bboxes);
+        let centroid = parts.length >= 6 ? JSON.parse(parts[5]).map(x => parseFloat(x)) : undefined;
+        let c = new Country(code, name, continent, population, bboxes, centroid);
         self.countries_[code] = c;
         self.countriesByName_[name] = c;
-        const centroid = c.getCentroid();
+        centroid = c.getCentroid();
         locationInfo['' + centroid[1] + '|' + centroid[0]] = '||' + code;
       }
     });

--- a/scripts/data_util.py
+++ b/scripts/data_util.py
@@ -20,9 +20,10 @@ def initialize_country_names_and_codes():
     with open(data_file) as f:
         data = f.read().strip()
         f.close()
-    pairs = data.split('\n')
-    for p in pairs:
-        (continent, code, name, population, _) = p.split(":")
+    records = data.split('\n')
+    for r in records:
+        fields = r.split(":")
+        (continent, code, name) = (fields[0], fields[1], fields[2])
         COUNTRIES_ISO_TO_NAME[code] = name
         COUNTRIES_NAME_TO_ISO[name.lower()] = code
     os.remove(data_file)


### PR DESCRIPTION
This will only work when https://github.com/globaldothealth/common/pull/2 is merged (which it now is)

The map now uses pre-configured ideas of where a country's centroid is located, if possible. If it knows that, then rather than zooming to the first bounding box defined for a country, it zooms to the one that contains the centroid.

This is better than the previous behaviour, but still not great. We now zoom to New Zealand's North Island (the centroid being somewhere near Wellington), rather than the whole of North and South Islands, but it's still better than zooming to the Chatham Islands. Portugal and Norway both correctly zoom to their respective mainlands.