### PR TITLE
2012 dev links in dev map

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ You need to get a mapbox API key and set it to an environment variable:
 Then, to run the application locally, pick a disease, for instance 'covid-19'
 and:
 
-`./run covid-19`
+`./run covid-19 dev`
 
+Use either 'dev' or 'prod' as the second argument; it currently just picks the URL to point to the data portal.
 Then, in your browser, load http://localhost:8000
 
 ## With local data
@@ -36,6 +37,6 @@ Before deploying, commit your changes or sending a pull request, please run the 
 
 Run this:
 
-`./deploy covid-19 path/to/target`
+`./deploy covid-19 dev path/to/target`
 
-for the `covid-19` disease (replace as needed) and then copy the contents of the target directory as appropriate (e.g. to AWS).
+for the `covid-19` disease (replace as needed) and dev portal link (or prod) and then copy the contents of the target directory as appropriate (e.g. to AWS).

--- a/config.json
+++ b/config.json
@@ -21,13 +21,15 @@
     "data_src_url": "http://localhost:8001",
     "prod_line_list_url": "http://localhost:3002",
     "dev_line_list_url": "http://localhost:3002",
-    "name": "Local"
+    "name": "Local",
+    "linkto": []
   },
   "test-disease": {
     "url": "http://test.global.health",
     "data_src_url": "https://idontexist.thatsokay",
     "prod_line_list_url": "https://data.test.global.health",
     "dev_line_list_url": "https://dev-data.test.global.health",
-    "name": "Test Disease"
+    "name": "Test Disease",
+    "linkto": []
   }
 }

--- a/config.json
+++ b/config.json
@@ -2,23 +2,32 @@
   "covid-19": {
     "url": "http://covid-19.global.health",
     "data_src_url": "https://covid-19-aggregates.s3.amazonaws.com/",
+    "prod_line_list_url": "https://data.covid-19.global.health",
+    "dev_line_list_url": "https://dev-data.covid-19.global.health",
     "name": "COVID-19",
     "linkto": ["h1n1"]
   },
   "h1n1": {
     "url": "http://h1n1.global.health",
     "data_src_url": "https://h1n1-aggregates.s3.amazonaws.com/",
+    "comment": "The line lists for h1n1 don't exist, but this shows how you would set it up",
+    "prod_line_list_url": "https://data.h1n1.global.health",
+    "dev_line_list_url": "https://dev-data.h1n1.global.health",
     "name": "H1N1",
     "linkto": ["covid-19"]
   },
   "local": {
     "url": "http://localhost:8000",
     "data_src_url": "http://localhost:8001",
+    "prod_line_list_url": "http://localhost:3002",
+    "dev_line_list_url": "http://localhost:3002",
     "name": "Local"
   },
   "test-disease": {
     "url": "http://test.global.health",
     "data_src_url": "https://idontexist.thatsokay",
+    "prod_line_list_url": "https://data.test.global.health",
+    "dev_line_list_url": "https://dev-data.test.global.health",
     "name": "Test Disease"
   }
 }

--- a/deploy
+++ b/deploy
@@ -27,4 +27,4 @@ if os.path.exists(TARGET_PATH):
 os.mkdir(TARGET_PATH)
 
 if __name__ == '__main__':
-    deploy(DISEASE_ID, TARGET_PATH)
+    deploy(DISEASE_ID, DEPLOY_ENV, TARGET_PATH)

--- a/deploy
+++ b/deploy
@@ -8,15 +8,17 @@ import os
 import shlex
 import subprocess
 
-if len(sys.argv) < 3:
-    print("Usage: " + sys.argv[0] + " disease_id target_path")
+if len(sys.argv) != 4:
+    print("Usage: " + sys.argv[0] + " disease_id  environment target_path")
+    print("Where environment is either dev or prod")
     sys.exit(1)
 
 src_path = os.path.dirname(os.path.realpath(__file__))
 os.chdir(src_path)
 
 DISEASE_ID = sys.argv[1]
-TARGET_PATH = sys.argv[2]
+DEPLOY_ENV = sys.argv[2]
+TARGET_PATH = sys.argv[3]
 
 if os.path.exists(TARGET_PATH):
     print("Target '" + TARGET_PATH + "' already exists. "

--- a/js/aggregatemapview.js
+++ b/js/aggregatemapview.js
@@ -70,7 +70,7 @@ getPopupContentsForFeature(f) {
     props['variant1'].toLocaleString() + 
     ' <br>Variant B.1.351: ' + 
     props['variant2'].toLocaleString() + 
-    '</p><a class="popup" target="_blank" href="https://data.covid-19.global.health/cases?country=%22' + 
+    '</p><a class="popup" target="_blank" href="{{LINE_LIST_URL}}/cases?country=%22' + 
     props['countryname'] +
     '%22">Explore Country Data</a>';
   return contents;

--- a/js/aggregatemapviewb1351.js
+++ b/js/aggregatemapviewb1351.js
@@ -70,7 +70,7 @@ getPopupContentsForFeature(f) {
     props['variant1'].toLocaleString() + 
     ' <br>Variant B.1.351: ' + 
     props['variant2'].toLocaleString() + 
-    '</p><a class="popup" target="_blank" href="https://data.covid-19.global.health/cases?country=%22' + 
+    '</p><a class="popup" target="_blank" href="{{LINE_LIST_URL}}/cases?country=%22' + 
     props['countryname'] +
     '%22">Explore Country Data</a>';
   return contents;

--- a/js/aggregatemapviewp1.js
+++ b/js/aggregatemapviewp1.js
@@ -70,7 +70,7 @@ getPopupContentsForFeature(f) {
     props['variant1'].toLocaleString() + 
     ' <br>Variant B.1.351: ' + 
     props['variant2'].toLocaleString() + 
-    '</p><a class="popup" target="_blank" href="https://data.covid-19.global.health/cases?country=%22' + 
+    '</p><a class="popup" target="_blank" href="{{LINE_LIST_URL}}/cases?country=%22' + 
     props['countryname'] +
     '%22">Explore Country Data</a>';
   return contents;

--- a/js/casemapview.js
+++ b/js/casemapview.js
@@ -76,7 +76,7 @@ getPopupContentsForFeature(f) {
   let content = document.createElement('div');
   content.innerHTML = '<h2 class="popup-title">' + regionName + ', ' + countryName + '</h2>' +
     '<p class=popup-count>' + totalCaseCount.toLocaleString() + ' cases</p> ' +
-    '<a class="popup" target="_blank" href="https://data.covid-19.global.health/cases?country=%22' + 
+    '<a class="popup" target="_blank" href="{{LINE_LIST_URL}}/cases?country=%22' + 
     countryName +
     '%22&' + regionLevel + '=%22' + 
     regionName + 

--- a/js/dataprovider_test.js
+++ b/js/dataprovider_test.js
@@ -1,6 +1,6 @@
 function testNormalizeGeoId() {
-  assertEquals('0.0000|0.0000', DataProvider.normalizeGeoId('0|0'),
+  assertEquals('0.0000|0.0000', DataProvider.normalizeGeoId('0','0'),
                'GeoId normalization');
-  assertEquals('5.0000|-10.1234', DataProvider.normalizeGeoId('5|-10.12343'),
+  assertEquals('5.0000|-10.1234', DataProvider.normalizeGeoId('5','-10.12343'),
                'GeoId normalization');
 }

--- a/js/nav.js
+++ b/js/nav.js
@@ -258,7 +258,7 @@ Nav.prototype.dataLink = function() {
   const dataEl = document.createElement('div');
   dataEl.setAttribute('id', 'data');
   const linkEl = document.createElement('a');
-  linkEl.setAttribute('href','https://data.covid-19.global.health');
+  linkEl.setAttribute('href','{{LINE_LIST_URL}}');
   linkEl.textContent = 'G.h Data';
   dataEl.classList.add('navlink');
   document.getElementById('topbar').appendChild(dataEl);

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -135,7 +135,7 @@ SideBar.prototype.render = function() {
   // }
 
   document.getElementById('ghlist').onclick = function(e) {
-    window.location.href = 'https://data.covid-19.global.health/  ';
+    window.location.href = '{{LINE_LIST_URL}}';
   };
 
 };

--- a/js/twodcoveragemapview.js
+++ b/js/twodcoveragemapview.js
@@ -85,7 +85,7 @@ getPopupContentsForFeature(f) {
     props['aggregatetotal'].toLocaleString() + ')</p>' + 
     '<div class="coverage-container"><div class="coverage-bar" style="height:12px;width:' + 
     props['coverage']+ '%"></div></div>' +
-    '<a class="popup coverage" target="_blank" href="https://data.covid-19.global.health/cases?country=%22' + props['countryname'] +'%22">Explore Country Data</a>';
+    '<a class="popup coverage" target="_blank" href="{{LINE_LIST_URL}}/cases?country=%22' + props['countryname'] +'%22">Explore Country Data</a>';
   return contents;
 }
 

--- a/run
+++ b/run
@@ -25,10 +25,16 @@ if len(sys.argv) < 3:
     sys.exit(1)
 
 DISEASE_ID = sys.argv[1]
+DEPLOY_ENV = sys.argv[2]
+
+if DEPLOY_ENV not in ['dev', 'prod']:
+    print(f"Deployment environment must be dev or prod, not {DEPLOY_ENV}")
+    sys.exit(1)
 
 class VizHandler(SimpleHTTPRequestHandler):
 
     def send_head(self):
+        line_list_url = CONFIG[DISEASE_ID]["prod_line_list_url"] if DEPLOY_ENV == 'prod' else CONFIG[DISEASE_ID]["dev_line_list_url"]
         path = self.translate_path(self.path)
         if "favicon.ico" in path:
             self.send_response(404)
@@ -52,6 +58,10 @@ class VizHandler(SimpleHTTPRequestHandler):
         binary = path.endswith(".gif") or path.endswith(".png")
         f = open(path, "rb" if binary else "r")
         contents = f.read()
+        # there are many JS files that use the line list url, so always do this substitution
+        if ".js" in self.path:
+            contents = contents.replace("{{LINE_LIST_URL}}",
+                                        line_list_url)
         if "diseasemap.js" in self.path:
             if MAPBOX_API_VARNAME in os.environ:
                 contents = contents.replace("{{MAPBOX_API_TOKEN}}",

--- a/run
+++ b/run
@@ -18,8 +18,10 @@ with open("config.json") as f:
     CONFIG = json.loads(f.read())
     f.close()
 
-if len(sys.argv) < 2:
-    print("Please give me the disease ID as an argument, for instance 'covid-19'")
+if len(sys.argv) < 3:
+    my_name = os.path.basename(__file__)
+    print(f"Usage: {my_name} disease environment")
+    print(f"E.g. {my_name} covid-19 prod")
     sys.exit(1)
 
 DISEASE_ID = sys.argv[1]
@@ -121,7 +123,7 @@ def run():
         http.join()
 
     except KeyboardInterrupt:
-        print("Hit Crtl-C a second time to shut down.")
+        print("Hit Ctrl-C a second time to shut down.")
         sys.exit(0)
 
 if __name__ == '__main__':

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -163,10 +163,13 @@ def replace_string_in_dest_file(to_replace, replacement,
         f.close()
     return True
 
-def deploy(disease_id, target_path, quiet=False):
+def deploy(disease_id, deploy_env, target_path, quiet=False):
     if not check_dependencies():
         sys.exit(1)
-
+    if not deploy_env in ['dev', 'prod']:
+        print(f"Deployment environment must be dev or prod, not {deploy_env}")
+        sys.exit(1)
+    line_list_url = CONFIG[disease_id]["prod_line_list_url"] if deploy_env == "prod" else CONFIG[disease_id]["dev_line_list_url"]
     success = True
     success &= backup_pristine_files()
     success &= (os.system("sass css/styles.scss css/styles.css") == 0)
@@ -188,6 +191,11 @@ def deploy(disease_id, target_path, quiet=False):
     success &= replace_string_in_dest_file(
         "{{MAPBOX_API_TOKEN}}",
         MAPBOX_PROD_API_TOKEN, target_path, "js/bundle.js")
+    success &= replace_string_in_dest_file(
+        "{{LINE_LIST_URL}}",
+        line_list_url,
+        target_path,
+        "js/bundle.js")
     other_diseases = []
     for did in CONFIG[disease_id]["linkto"]:
         other_diseases.append("|".join([

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import shutil

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -26,7 +26,7 @@ class DeployTest(base_test.BaseTest):
             os.system("rm -rf " + TEST_TARGET)
         os.mkdir(TEST_TARGET)
         # Note: set 'quiet' to True for debugging failures.
-        deploy('test-disease', os.path.join(os.getcwd(), TEST_TARGET), quiet=True)
+        deploy('test-disease', 'dev', os.path.join(os.getcwd(), TEST_TARGET), quiet=True)
 
         self.check(
             self.target_file_contains("index.html", "google-analytics"),

--- a/tests/js_test.py
+++ b/tests/js_test.py
@@ -56,7 +56,7 @@ class JsTest(base_test.BaseTest):
         with open(TEMP_TEST_CONCATENATION, "w") as f:
             f.write(full_contents)
             f.close()
-        return_code = os.system("nodejs " + TEMP_TEST_CONCATENATION)
+        return_code = os.system("node --trace-uncaught " + TEMP_TEST_CONCATENATION)
         if return_code == 0:
             os.system("rm -f " + TEMP_TEST_CONCATENATION)
         self.check(return_code == 0, "JS tests failed")


### PR DESCRIPTION
Choose either 'dev' or 'prod' when running or deploying the map; links to data portal are configured appropriately. Fixes [list#2012](https://github.com/globaldothealth/list/issues/2012); groundwork for fixing #1631.